### PR TITLE
fix: add image link to filmlog-02

### DIFF
--- a/src/app/posts/_articles/filmlog-02/post.mdx
+++ b/src/app/posts/_articles/filmlog-02/post.mdx
@@ -10,6 +10,7 @@ export const metadata = {
 };
 
 ![](https://files.toosign.me/cdn-cgi/image/format=avif,quality=100,width=800,fit=scale-down,onerror=redirect/image/filmlog-02/000446340031_28.JPG)  
+![](https://files.toosign.me/cdn-cgi/image/format=avif,quality=100,width=800,fit=scale-down,onerror=redirect/image/filmlog-02/000446350009_6A.jpg)  
 ![](https://files.toosign.me/cdn-cgi/image/format=avif,quality=100,width=800,fit=scale-down,onerror=redirect/image/filmlog-02/000446340021_18.JPG)  
 ![](https://files.toosign.me/cdn-cgi/image/format=avif,quality=100,width=800,fit=scale-down,onerror=redirect/image/filmlog-02/000446340007_4.JPG)  
 ![](https://files.toosign.me/cdn-cgi/image/format=avif,quality=100,width=800,fit=scale-down,onerror=redirect/image/filmlog-02/000446340011_8.JPG)  
@@ -19,11 +20,9 @@ export const metadata = {
 ![](https://files.toosign.me/cdn-cgi/image/format=avif,quality=100,width=800,fit=scale-down,onerror=redirect/image/filmlog-02/000446340019_16.JPG)  
 ![](https://files.toosign.me/cdn-cgi/image/format=avif,quality=100,width=800,fit=scale-down,onerror=redirect/image/filmlog-02/000446340026_23.JPG)  
 ![](https://files.toosign.me/cdn-cgi/image/format=avif,quality=100,width=800,fit=scale-down,onerror=redirect/image/filmlog-02/000446340033_30.JPG)  
-![](https://files.toosign.me/cdn-cgi/image/format=avif,quality=100,width=800,fit=scale-down,onerror=redirect/image/filmlog-02/000446350009_6A.jpg)  
-![](https://files.toosign.me/cdn-cgi/image/format=avif,quality=100,width=800,fit=scale-down,onerror=redirect/image/filmlog-02/000446330036_33A.JPG)  
-![](https://files.toosign.me/cdn-cgi/image/format=avif,quality=100,width=800,fit=scale-down,onerror=redirect/image/filmlog-02/000446300025_22A.JPG)  
+![](https://files.toosign.me/cdn-cgi/image/format=avif,quality=100,width=800,fit=scale-down,onerror=redirect/image/filmlog-02/000446330036_33A.JPG)   
 ![](https://files.toosign.me/cdn-cgi/image/format=avif,quality=100,width=800,fit=scale-down,onerror=redirect/image/filmlog-02/000446300035_32A.jpg)  
 ![](https://files.toosign.me/cdn-cgi/image/format=avif,quality=100,width=800,fit=scale-down,onerror=redirect/image/filmlog-02/000446300036_33A.JPG)  
 ![](https://files.toosign.me/cdn-cgi/image/format=avif,quality=100,width=800,fit=scale-down,onerror=redirect/image/filmlog-02/000446290006.JPG)  
-![](https://files.toosign.me/cdn-cgi/image/format=avif,quality=100,width=800,fit=scale-down,onerror=redirect/image/filmlog-02/000446290017.JPG)  
+![](https://files.toosign.me/cdn-cgi/image/format=avif,quality=100,width=800,fit=scale-down,onerror=redirect/image/filmlog-02/000446290017.JPG)   
  


### PR DESCRIPTION
## Summary
- Added a missing image link to the filmlog-02 entry.

## Changes
- Updated the filmlog-02 entry to include the correct image link.

## Test Plan
- [x] Verify that the image link in filmlog-02 is correct and functional.
- [x] Ensure no other parts of the filmlog are affected.

## Notes
> None