### PR TITLE
fix: restore LinkEmbed favicon dimensions for next/image

### DIFF
--- a/src/components/ui/linkEmbed.tsx
+++ b/src/components/ui/linkEmbed.tsx
@@ -3,14 +3,14 @@ import Image from 'next/image';
 import type { ComponentProps } from 'react';
 import { useEffect, useState } from 'react';
 
-type LinkEmbedProps = ComponentProps<'a'> & {
+interface LinkEmbedProps extends ComponentProps<'a'> {
   url: string;
   title?: string;
   description?: string;
   thumbnail?: string;
   favicon?: string;
   variant?: 'card' | 'mention';
-};
+}
 
 interface LinkMetadata {
   title?: string;
@@ -134,7 +134,7 @@ export const LinkEmbed = ({
         {!faviconError && (
           <Image
             alt=''
-            className='shrink-0 rounded-full'
+            className='h-3.5 w-3.5 shrink-0 rounded-full'
             height={14}
             src={favicon}
             unoptimized
@@ -205,7 +205,7 @@ export const LinkEmbed = ({
               {!faviconError && (
                 <Image
                   alt=''
-                  className='shrink-0 rounded'
+                  className='h-4 w-4 shrink-0 rounded'
                   height={16}
                   src={favicon}
                   unoptimized


### PR DESCRIPTION
## Summary
- Fixed the favicon dimensions in the LinkEmbed component to properly work with next/image.

## Changes
- Adjusted favicon rendering logic in the LinkEmbed component.

## Test Plan
- [x] Verify that favicons in the LinkEmbed component render with correct dimensions.
- [x] Test across different browsers and devices to ensure consistent behavior.

## Notes
> This fix ensures compatibility with next/image while maintaining proper styling for favicons.