### PR TITLE
add google sheets icon and update profile card styles

### DIFF
--- a/src/components/about/ProfileCard.tsx
+++ b/src/components/about/ProfileCard.tsx
@@ -16,7 +16,7 @@ export const ProfileCard = async () => {
       <h1 className='h3 text-gray-light'>About</h1>
       <section>
         <div
-          className='w-full p-7.5 rounded-t-2xl shadow-[inset_0_0.125rem_0.125rem_rgba(255,255,255,0.3)]'
+          className='w-full p-7.5 rounded-t-2xl'
           style={{ backgroundColor: ABOUT.profile.cardBackgroundColor }}
         >
           <div className='flex items-center gap-8'>
@@ -54,7 +54,7 @@ export const ProfileCard = async () => {
         <div className='flex flex-col tablet:flex-row w-full'>
           <ResumeDownloadButton
             fileUrl={ABOUT.profile.resumeUrl}
-            className='cursor-pointer relative overflow-hidden flex-1 flex items-center justify-center gap-2 px-4 py-3 hover:brightness-95 active:brightness-95 transition-all border-l border-b border-r border-t-0 border-white/5 rounded-none tablet:rounded-bl-2xl shadow-[inset_0_-0.125rem_0.125rem_rgba(255,255,255,0.3)]'
+            className='cursor-pointer relative overflow-hidden flex-1 flex items-center justify-center gap-2 px-4 py-3 hover:brightness-95 active:brightness-95 transition-all border-l border-b border-r border-t-0 border-white/5 rounded-none tablet:rounded-bl-2xl'
             style={{
               backgroundColor: ABOUT.profile.cardBackgroundColor,
               color: ABOUT.profile.contentTextColor,
@@ -68,7 +68,7 @@ export const ProfileCard = async () => {
           </ResumeDownloadButton>
           <ResumeDownloadButton
             fileUrl={ABOUT.profile.coverLetterUrl}
-            className='cursor-pointer relative overflow-hidden flex-1 flex items-center justify-center gap-2 px-4 py-3 hover:brightness-95 active:brightness-95 transition-all border-l border-b border-r border-t-0 tablet:border-l-0 border-white/10 rounded-b-2xl tablet:rounded-bl-none tablet:rounded-br-2xl shadow-[inset_0_-0.125rem_0.125rem_rgba(255,255,255,0.3)]'
+            className='cursor-pointer relative overflow-hidden flex-1 flex items-center justify-center gap-2 px-4 py-3 hover:brightness-95 active:brightness-95 transition-all border-l border-b border-r border-t-0 tablet:border-l-0 border-white/10 rounded-b-2xl tablet:rounded-bl-none tablet:rounded-br-2xl'
             style={{
               backgroundColor: ABOUT.profile.cardBackgroundColor,
               color: ABOUT.profile.contentTextColor,

--- a/src/components/about/SkillBadge.tsx
+++ b/src/components/about/SkillBadge.tsx
@@ -11,8 +11,10 @@ export const SkillBadge = ({ icon, label }: SkillBadgeProps) => {
     <span className='inline-flex items-center gap-1.5 px-3 py-2 rounded-sm border border-border bg-background02 text-gray-bold text-sm font-medium hover:bg-background03 transition-colors'>
       <span className='shrink-0 flex items-center gap-1'>
         {icons.map((ic, i) => (
-          // biome-ignore lint/suspicious/noArrayIndexKey: static icon list
-          <span key={i} className='flex items-center justify-center w-5 h-5'>
+          <span
+            key={ic && typeof ic === 'object' && 'key' in ic && ic.key != null ? ic.key : i}
+            className='flex items-center justify-center w-5 h-5'
+          >
             {ic}
           </span>
         ))}

--- a/src/components/about/SkillsSection.tsx
+++ b/src/components/about/SkillsSection.tsx
@@ -8,6 +8,7 @@ import { FigmaIcon } from '@/components/icons/FigmaIcon';
 import { GeminiIcon } from '@/components/icons/GeminiIcon';
 import { GithubIcon } from '@/components/icons/GithubIcon';
 import { GitIcon } from '@/components/icons/GitIcon';
+import { GoogleSheetsIcon } from '@/components/icons/GoogleSheetsIcon';
 import { JavaScriptIcon } from '@/components/icons/JavaScriptIcon';
 import { JiraIcon } from '@/components/icons/JiraIcon';
 import { MySQLIcon } from '@/components/icons/MySQLIcon';
@@ -38,6 +39,7 @@ const ICON_MAP: Record<string, ComponentType<IconProps>> = {
   git: GitIcon,
   github: GithubIcon,
   figma: FigmaIcon,
+  googlesheets: GoogleSheetsIcon,
 };
 
 export const SkillsSection = () => {

--- a/src/components/icons/GoogleSheetsIcon.tsx
+++ b/src/components/icons/GoogleSheetsIcon.tsx
@@ -1,0 +1,23 @@
+import type { IconProps } from '@/types/icon.types';
+
+export const GoogleSheetsIcon = ({ size = 24, ...props }: IconProps) => (
+  <svg
+    xmlns='http://www.w3.org/2000/svg'
+    width={size}
+    height={size}
+    viewBox='0 0 314.7 428'
+    fill='none'
+    {...props}
+  >
+    <title>Google Sheets</title>
+    <path d='M206 108.7h108.7L206 0z' fill='#188038' />
+    <path
+      d='M206 108.7V0H24C10.7 0 0 10.7 0 24v380c0 13.3 10.7 24 24 24h266.7c13.3 0 24-10.7 24-24V108.7z'
+      fill='#34a853'
+    />
+    <path
+      d='M60 167.9V315h194.7V167.9zM145.3 291H84v-37.6h61.3zm0-61.5H84v-37.6h61.3zm85.4 61.5h-61.3v-37.6h61.3zm0-61.5h-61.3v-37.6h61.3z'
+      fill='#fff'
+    />
+  </svg>
+);

--- a/src/constants/about.constants.ts
+++ b/src/constants/about.constants.ts
@@ -77,6 +77,7 @@ export const ABOUT = {
         { label: 'Confluence', icon: 'confluence' },
         { label: 'Slack', icon: 'slack' },
         { label: 'Notion', icon: 'notion' },
+        { label: 'Google Sheets', icon: 'googlesheets' },
         { label: 'Git', icon: 'git' },
         { label: 'GitHub', icon: 'github' },
         { label: 'Figma', icon: 'figma' },


### PR DESCRIPTION
## Summary
- Removed inset box-shadow from ProfileCard header and download buttons
- Fixed SkillBadge key by using element key instead of array index
- Added Google Sheets icon to SkillsSection
- Included Google Sheets in Tools & Communication skills list

## Changes
- Updated `ProfileCard` styles to remove inset box-shadow
- Modified `SkillBadge` to use proper keys for rendering
- Added `GoogleSheetsIcon` component
- Updated `SkillsSection` to include Google Sheets in the icon map and skills list

## Test Plan
- [x] Verify ProfileCard header and download buttons no longer have inset box-shadow
- [x] Confirm SkillBadge renders correctly with unique keys
- [x] Check that Google Sheets icon appears in the SkillsSection
- [x] Ensure Google Sheets is listed under Tools & Communication skills