### PR TITLE
add per-post view count tracking and display

### DIFF
--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -1,24 +1,29 @@
 import { cookies } from 'next/headers';
-import { NextResponse } from 'next/server';
+import { type NextRequest, NextResponse } from 'next/server';
 import { queryD1 } from '@/utils/d1-util';
 import { getKstDateKey, getStats } from '@/utils/stats-util';
 
 const COUNT_INTERVAL_MS = 15 * 60 * 1000;
 const LAST_COUNTED_COOKIE = 'stats_last_counted_at';
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
-    const stats = await getStats();
+    const pathname = request.nextUrl.searchParams.get('pathname') ?? '/';
+    const stats = await getStats(pathname);
     return NextResponse.json(stats);
   } catch {
     return NextResponse.json({ today: 0, total: 0 }, { status: 500 });
   }
 }
 
-export async function POST() {
+export async function POST(request: NextRequest) {
   try {
+    const body = await request.json().catch(() => ({}));
+    const pathname: string = body.pathname ?? '/';
+
     const cookieStore = await cookies();
-    const lastCountedAt = Number(cookieStore.get(LAST_COUNTED_COOKIE)?.value ?? '0');
+    const cookieKey = `${LAST_COUNTED_COOKIE}_${pathname.replace(/\//g, '_')}`;
+    const lastCountedAt = Number(cookieStore.get(cookieKey)?.value ?? '0');
     const now = Date.now();
 
     if (lastCountedAt > 0 && now - lastCountedAt < COUNT_INTERVAL_MS) {
@@ -29,14 +34,14 @@ export async function POST() {
 
     await queryD1(
       `INSERT INTO page_views (date, pathname, count)
-       VALUES (?, '/', 1)
+       VALUES (?, ?, 1)
        ON CONFLICT(date, pathname) DO UPDATE SET count = count + 1`,
-      [today]
+      [today, pathname]
     );
 
     const response = NextResponse.json({ ok: true, counted: true });
     response.cookies.set({
-      name: LAST_COUNTED_COOKIE,
+      name: cookieKey,
       value: String(now),
       httpOnly: true,
       sameSite: 'lax',

--- a/src/app/categories/[category]/page.tsx
+++ b/src/app/categories/[category]/page.tsx
@@ -6,6 +6,7 @@ import { POST } from '@/constants/metadata.constants';
 import { generatePageMetadata } from '@/utils/metadata-util';
 import { parsePageParam } from '@/utils/page-param-util';
 import { getAllPosts } from '@/utils/post-util';
+import { getPostsViews } from '@/utils/stats-util';
 import { slugify } from '@/utils/text-util';
 
 interface CategoriesPageProps {
@@ -24,7 +25,12 @@ const CategoriesPage = async ({ params, searchParams }: CategoriesPageProps) => 
 
   const start = (currentPage - 1) * POST.PER_PAGE;
   const end = start + POST.PER_PAGE;
-  const currentPosts = categoryPosts.slice(start, end);
+  const pageCategoryPosts = categoryPosts.slice(start, end);
+  const views = await getPostsViews(pageCategoryPosts.map((p) => p.slug));
+  const currentPosts = pageCategoryPosts.map((p) => ({
+    ...p,
+    views: views[`/posts/${p.slug}`] ?? 0,
+  }));
 
   return (
     <>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,12 +7,15 @@ import { PostGrid } from '@/components/ui/postGrid';
 import { ROUTES } from '@/constants/menu.constants';
 import { generatePageMetadata } from '@/utils/metadata-util';
 import { getAllPosts } from '@/utils/post-util';
+import { getPostsViews } from '@/utils/stats-util';
 
-const getLatestPosts = <T,>(posts: T[]) => posts.slice(0, 2);
+const getLatestPosts = <T extends { slug: string }>(posts: T[]) => posts.slice(0, 2);
 
 const HomePage = async () => {
   const allPosts = await getAllPosts();
-  const posts = getLatestPosts(allPosts);
+  const latestPosts = getLatestPosts(allPosts);
+  const views = await getPostsViews(latestPosts.map((p) => p.slug));
+  const posts = latestPosts.map((p) => ({ ...p, views: views[`/posts/${p.slug}`] ?? 0 }));
 
   return (
     <>

--- a/src/app/posts/[slug]/_components/header.tsx
+++ b/src/app/posts/[slug]/_components/header.tsx
@@ -1,11 +1,24 @@
 import Image from 'next/image';
 import Link from 'next/link';
+import type { ReactNode } from 'react';
 import { RelativeTime } from '@/components/ui/relativeTime';
 import { ROUTES } from '@/constants/menu.constants';
 import type { Post } from '@/types/content.types';
 import { slugify } from '@/utils/text-util';
 
-export const Header = ({ coverImage, title, subtitle, createdAt, category, tags }: Post) => {
+interface HeaderProps extends Post {
+  viewCounter: ReactNode;
+}
+
+export const Header = ({
+  coverImage,
+  title,
+  subtitle,
+  createdAt,
+  category,
+  tags,
+  viewCounter,
+}: HeaderProps) => {
   return (
     <header className='mt-5 mb-14'>
       <div className='center relative aspect-[1.8/1] w-full select-none overflow-hidden rounded-lg border border-border'>
@@ -38,6 +51,7 @@ export const Header = ({ coverImage, title, subtitle, createdAt, category, tags 
             </Link>
           </>
         )}
+        <span className='ml-auto mr-2'>{viewCounter}</span>
       </p>
 
       {tags && tags?.length > 0 && (

--- a/src/app/posts/[slug]/_components/view-counter.tsx
+++ b/src/app/posts/[slug]/_components/view-counter.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { Eye } from 'lucide-react';
+import { useEffect, useRef } from 'react';
+
+interface ViewCounterProps {
+  pathname: string;
+  initialTotal: number;
+}
+
+export const ViewCounter = ({ pathname, initialTotal }: ViewCounterProps) => {
+  const hasCounted = useRef(false);
+
+  useEffect(() => {
+    if (hasCounted.current) return;
+    hasCounted.current = true;
+    void fetch('/api/stats', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ pathname }),
+    });
+  }, [pathname]);
+
+  return (
+    <span className='center-y gap-1'>
+      <Eye size={12} />
+      {initialTotal.toLocaleString()}
+    </span>
+  );
+};

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -6,11 +6,13 @@ import { METADATA } from '@/constants/metadata.constants';
 import type { Post } from '@/types/content.types';
 import { generatePageMetadata } from '@/utils/metadata-util';
 import { getAllPosts, getPostBySlug, getPostPageDataBySlug } from '@/utils/post-util';
+import { getStats } from '@/utils/stats-util';
 import { BackButton } from './_components/back-button';
 import { Footer } from './_components/footer';
 import { Giscus } from './_components/giscus';
 import { Header } from './_components/header';
 import { Recommend } from './_components/recommend';
+import { ViewCounter } from './_components/view-counter';
 
 interface PostPageProps {
   params: Promise<{ slug: string }>;
@@ -31,14 +33,18 @@ const PostPage = async ({ params }: PostPageProps) => {
     notFound();
   }
 
-  const allPosts = await getAllPosts();
+  const pathname = `/posts/${slug}`;
+  const [allPosts, postStats] = await Promise.all([getAllPosts(), getStats(pathname)]);
 
   return (
     <>
       <BackButton />
 
       <article>
-        <Header {...post} />
+        <Header
+          {...post}
+          viewCounter={<ViewCounter initialTotal={postStats.total} pathname={pathname} />}
+        />
         <MDXContent />
 
         {post.comments && <Giscus className='mt-14' />}

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -6,6 +6,7 @@ import { POST } from '@/constants/metadata.constants';
 import { generatePageMetadata } from '@/utils/metadata-util';
 import { parsePageParam } from '@/utils/page-param-util';
 import { getAllPosts } from '@/utils/post-util';
+import { getPostsViews } from '@/utils/stats-util';
 
 interface PostsPageProps {
   searchParams: Promise<{ page: string }>;
@@ -18,7 +19,9 @@ const PostsPage = async ({ searchParams }: PostsPageProps) => {
   const end = start + POST.PER_PAGE;
 
   const allPosts = await getAllPosts();
-  const currentPosts = allPosts.slice(start, end);
+  const pagePosts = allPosts.slice(start, end);
+  const views = await getPostsViews(pagePosts.map((p) => p.slug));
+  const currentPosts = pagePosts.map((p) => ({ ...p, views: views[`/posts/${p.slug}`] ?? 0 }));
 
   return (
     <>

--- a/src/app/tags/[tag]/page.tsx
+++ b/src/app/tags/[tag]/page.tsx
@@ -6,6 +6,7 @@ import { POST } from '@/constants/metadata.constants';
 import { generatePageMetadata } from '@/utils/metadata-util';
 import { parsePageParam } from '@/utils/page-param-util';
 import { getAllPosts } from '@/utils/post-util';
+import { getPostsViews } from '@/utils/stats-util';
 import { decodeSlugSegment, slugify } from '@/utils/text-util';
 
 interface TagsPageProps {
@@ -24,7 +25,9 @@ const TagsPage = async ({ params, searchParams }: TagsPageProps) => {
 
   const start = (currentPage - 1) * POST.PER_PAGE;
   const end = start + POST.PER_PAGE;
-  const currentPosts = tagPosts.slice(start, end);
+  const pageTagPosts = tagPosts.slice(start, end);
+  const views = await getPostsViews(pageTagPosts.map((p) => p.slug));
+  const currentPosts = pageTagPosts.map((p) => ({ ...p, views: views[`/posts/${p.slug}`] ?? 0 }));
 
   const tagName =
     tagPosts[0]?.tags?.find((t) => slugify(t) === tagKey) ?? decodeSlugSegment(rawTag);

--- a/src/components/ui/lazyImage.tsx
+++ b/src/components/ui/lazyImage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Image, { type ImageProps } from 'next/image';
+import Image from 'next/image';
 import type { CSSProperties } from 'react';
 import { useState } from 'react';
 import { twMerge } from 'tailwind-merge';
@@ -12,7 +12,7 @@ export type LazyImageProps = {
   draggable?: boolean;
   title?: string;
   style?: CSSProperties;
-  onLoadingComplete?: ImageProps['onLoadingComplete'];
+  onLoad?: () => void;
 };
 
 export const LazyImage = ({
@@ -22,7 +22,7 @@ export const LazyImage = ({
   draggable = false,
   title,
   style,
-  onLoadingComplete,
+  onLoad,
 }: LazyImageProps) => {
   const [isLoaded, setIsLoaded] = useState(false);
 
@@ -36,9 +36,9 @@ export const LazyImage = ({
       )}
       draggable={draggable}
       height={800}
-      onLoadingComplete={(img) => {
+      onLoad={() => {
         setIsLoaded(true);
-        onLoadingComplete?.(img);
+        onLoad?.();
       }}
       sizes='(max-width: 768px) 100vw, 1200px'
       src={src}

--- a/src/components/ui/postGrid.tsx
+++ b/src/components/ui/postGrid.tsx
@@ -18,7 +18,7 @@ export const PostGrid = ({ posts, className, ...props }: PostGridProps) => {
       className={twMerge('grid w-full grid-cols-1 tablet:grid-cols-2 gap-16', className)}
       {...props}
     >
-      {posts.map(({ _id, slug, title, coverImage, createdAt }, index) => {
+      {posts.map(({ _id, slug, title, coverImage, createdAt, views }, index) => {
         return (
           <Link
             aria-label={`Read post: ${title}`}
@@ -43,10 +43,12 @@ export const PostGrid = ({ posts, className, ...props }: PostGridProps) => {
               {title}
             </h2>
 
-            <RelativeTime
-              className='description h4 -mx-2.5 mt-4 -mb-0.5 w-fit rounded-sm px-2.5 py-0.5 text-gray-light transition-colors duration-250 ease-in-out'
-              time={createdAt}
-            />
+            <p className='description h4 center-y -mx-2.5 mt-4 -mb-0.5 w-fit rounded-sm px-2.5 py-0.5 text-gray-light transition-colors duration-250 ease-in-out'>
+              <RelativeTime time={createdAt} />
+              {views !== undefined && (
+                <span className='ml-4 tabular-nums'>{views.toLocaleString()} views</span>
+              )}
+            </p>
           </Link>
         );
       })}

--- a/src/components/ui/postList.tsx
+++ b/src/components/ui/postList.tsx
@@ -15,50 +15,55 @@ type PostListProps = ComponentProps<'ul'> & {
 export const PostList = ({ posts, className, ...props }: PostListProps) => {
   return (
     <ul className={twMerge('column list-none gap-7.5', className)} {...props}>
-      {posts.map(({ _id, slug, title, subtitle, coverImage, category, createdAt }, index) => (
-        <li key={_id}>
-          <Link
-            aria-label={`Read post: ${title}`}
-            className={twMerge(
-              'flex cursor-pointer flex-col gap-4.5 tablet:flex-row tablet:gap-8.75',
-              POST_CARD_INTERACTION_CLASS,
-              'hover:[&_.subtitle]:bg-gray-hover active:[&_.subtitle]:bg-border'
-            )}
-            href={`${ROUTES.POSTS}/${slug}`}
-          >
-            <div className='relative aspect-[1.8/1] w-full overflow-hidden rounded-lg border border-border tablet:w-86.5'>
-              <Image
-                alt={`${title} Cover Image`}
-                className='h-full w-full object-cover object-center'
-                draggable={false}
-                fill
-                priority={index === 0}
-                quality={100}
-                sizes='(max-width: 59.9375rem) 100vw, 21.625rem'
-                src={coverImage}
-              />
-            </div>
+      {posts.map(
+        ({ _id, slug, title, subtitle, coverImage, category, createdAt, views }, index) => (
+          <li key={_id}>
+            <Link
+              aria-label={`Read post: ${title}`}
+              className={twMerge(
+                'flex cursor-pointer flex-col gap-4.5 tablet:flex-row tablet:gap-8.75',
+                POST_CARD_INTERACTION_CLASS,
+                'hover:[&_.subtitle]:bg-gray-hover active:[&_.subtitle]:bg-border'
+              )}
+              href={`${ROUTES.POSTS}/${slug}`}
+            >
+              <div className='relative aspect-[1.8/1] w-full shrink-0 overflow-hidden rounded-lg border border-border tablet:w-86.5'>
+                <Image
+                  alt={`${title} Cover Image`}
+                  className='h-full w-full object-cover object-center'
+                  draggable={false}
+                  fill
+                  priority={index === 0}
+                  quality={100}
+                  sizes='(max-width: 59.9375rem) 100vw, 21.625rem'
+                  src={coverImage}
+                />
+              </div>
 
-            <div className='column flex-1'>
-              <h2 className='title post-subtitle -mx-2.5 -mb-0.5 rounded-sm px-2.5 py-0.5 text-gray-accent transition-colors duration-250 ease-in-out'>
-                {title}
-              </h2>
-              <p className='subtitle post-description -mx-2.5 mt-3 -mb-0.5 rounded-sm px-2.5 py-0.5 text-gray-mid transition-colors duration-250 ease-in-out tablet:mt-5'>
-                {subtitle}
-              </p>
-              <p className='description center-y h5 -mx-2.5 mt-2 -mb-0.5 w-fit rounded-sm px-2.5 py-0.5 text-gray-light transition-colors duration-250 ease-in-out tablet:mt-4.5'>
-                <RelativeTime time={createdAt} />
-                {category && (
-                  <>
-                    <span className='text-gray-bold'>&nbsp;&middot;&nbsp;</span>
-                    {category}
-                  </>
-                )}
-              </p>
-            </div>
-          </Link>
-        </li>
-      ))}
+              <div className='column flex-1'>
+                <h2 className='title post-subtitle -mx-2.5 -mb-0.5 rounded-sm px-2.5 py-0.5 text-gray-accent transition-colors duration-250 ease-in-out'>
+                  {title}
+                </h2>
+                <p className='subtitle post-description -mx-2.5 mt-3 -mb-0.5 rounded-sm px-2.5 py-0.5 text-gray-mid transition-colors duration-250 ease-in-out tablet:mt-5'>
+                  {subtitle}
+                </p>
+                <p className='description center-y h5 -mx-2.5 mt-2 -mb-0.5 w-fit rounded-sm px-2.5 py-0.5 text-gray-light transition-colors duration-250 ease-in-out tablet:mt-4.5'>
+                  <RelativeTime time={createdAt} />
+                  {category && (
+                    <>
+                      <span className='text-gray-bold'>&nbsp;&middot;&nbsp;</span>
+                      {category}
+                    </>
+                  )}
+                  {views !== undefined && (
+                    <span className='ml-4 tabular-nums'>{views.toLocaleString()} views</span>
+                  )}
+                </p>
+              </div>
+            </Link>
+          </li>
+        )
+      )}
     </ul>
   );
 };

--- a/src/types/content.types.ts
+++ b/src/types/content.types.ts
@@ -12,4 +12,5 @@ export interface PostMetadata {
 export interface Post extends PostMetadata {
   _id: string;
   slug: string;
+  views?: number;
 }

--- a/src/utils/stats-util.ts
+++ b/src/utils/stats-util.ts
@@ -1,24 +1,43 @@
+import dayjs from 'dayjs';
+import timezone from 'dayjs/plugin/timezone';
+import utc from 'dayjs/plugin/utc';
 import { queryD1 } from '@/utils/d1-util';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 export interface Stats {
   today: number;
   total: number;
 }
 
-const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
-
 export function getKstDateKey(date = new Date()): string {
-  return new Date(date.getTime() + KST_OFFSET_MS).toISOString().slice(0, 10);
+  return dayjs(date).tz('Asia/Seoul').format('YYYY-MM-DD');
 }
 
-export async function getStats(): Promise<Stats> {
+export async function getStats(pathname = '/'): Promise<Stats> {
   const today = getKstDateKey();
   const rows = await queryD1<Stats>(
     `SELECT
       COALESCE(SUM(CASE WHEN date = ? THEN count ELSE 0 END), 0) as today,
       COALESCE(SUM(count), 0) as total
-    FROM page_views`,
-    [today]
+    FROM page_views
+    WHERE pathname = ?`,
+    [today, pathname]
   );
   return { today: rows[0]?.today ?? 0, total: rows[0]?.total ?? 0 };
+}
+
+export async function getPostsViews(slugs: string[]): Promise<Record<string, number>> {
+  if (slugs.length === 0) return {};
+  const placeholders = slugs.map(() => '?').join(', ');
+  const pathnames = slugs.map((slug) => `/posts/${slug}`);
+  const rows = await queryD1<{ pathname: string; total: number }>(
+    `SELECT pathname, COALESCE(SUM(count), 0) as total
+     FROM page_views
+     WHERE pathname IN (${placeholders})
+     GROUP BY pathname`,
+    pathnames
+  );
+  return Object.fromEntries(rows.map((r) => [r.pathname, r.total]));
 }


### PR DESCRIPTION
## Summary
- Implemented tracking and display of view counts for individual posts
- Enhanced API with pathname parameter support for stats endpoints
- Updated post type to include view count field
- Migrated date handling to use dayjs with UTC/timezone plugins

## Changes
- Added `pathname` parameter support to `GET/POST /api/stats`
- Implemented `getStats` and `getPostsViews` for querying view counts by pathname
- Updated `Post` type to include `views` field
- Displayed view counts in post headers and list/grid cards
- Migrated KST date handling to dayjs with UTC/timezone plugins

## Test Plan
- [x] Verify view counts are tracked and updated correctly for individual posts
- [x] Confirm `GET/POST /api/stats` endpoints handle `pathname` parameter as expected
- [x] Ensure view counts are displayed accurately in post headers and list/grid cards
- [x] Test date handling to ensure correct timezone and formatting

## Notes
> Migrating to dayjs improves consistency and maintainability for date handling.