### PR TITLE
fix: refetch stats after POST and reduce staleTime

### DIFF
--- a/src/hooks/useStats.ts
+++ b/src/hooks/useStats.ts
@@ -22,7 +22,7 @@ export function useStatsQuery(pathname: string, initialData: Stats) {
     queryKey: statsQueryKey(pathname),
     queryFn: () => fetchStats(pathname),
     initialData,
-    staleTime: Infinity,
+    staleTime: 60_000,
   });
 }
 
@@ -31,10 +31,8 @@ export function useStatsMutation(pathname: string) {
 
   return useMutation({
     mutationFn: () => postStats(pathname),
-    onSuccess: ({ counted }) => {
-      if (counted) {
-        void queryClient.invalidateQueries({ queryKey: statsQueryKey(pathname) });
-      }
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: statsQueryKey(pathname) });
     },
   });
 }


### PR DESCRIPTION
## Summary
- Ensure stats are always refetched after a POST request.
- Reduce staleTime configuration to 1 minute to minimize outdated data.

## Changes
- Updated logic to trigger stats refetch after POST requests.
- Adjusted staleTime setting in the relevant configuration.

## Test Plan
- [x] Verify stats are refetched immediately after a POST request.
- [x] Confirm staleTime is set to 1 minute and behaves as expected.

## Notes
> Reduced staleTime may increase API calls; monitor for performance impact.