### PR TITLE
fix: force-dynamic on home and posts pages for view counts

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,6 +45,8 @@ const HomePage = async () => {
 
 export default HomePage;
 
+export const dynamic = 'force-dynamic';
+
 export const generateMetadata = (): Metadata =>
   generatePageMetadata({
     path: ROUTES.HOME,

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -40,6 +40,8 @@ const PostsPage = async ({ searchParams }: PostsPageProps) => {
 
 export default PostsPage;
 
+export const dynamic = 'force-dynamic';
+
 export const generateStaticParams = async () => {
   const allPosts = await getAllPosts();
   const totalPages = Math.ceil(allPosts.length / POST.PER_PAGE);


### PR DESCRIPTION
## Summary
- Ensured the home and posts pages dynamically update to reflect the latest view counts.

## Changes
- Applied `force-dynamic` to the home page.
- Applied `force-dynamic` to the posts page.

## Test Plan
- [x] Verify that view counts on the home page update dynamically.
- [x] Verify that view counts on the posts page update dynamically.

## Notes
> This change ensures real-time updates for view counts on key pages.