### PR TITLE
improve ci workflows and add e2e test suite

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,40 +1,48 @@
-contentlayer:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - 'contentlayer.config.ts'
-              - 'config/contentlayer/**'
-
 dependencies:
   - any:
       - changed-files:
           - any-glob-to-any-file:
               - 'pnpm-lock.yaml'
+              - 'package.json'
 
-documentation:
+post:
   - any:
       - changed-files:
           - any-glob-to-any-file:
-              - 'content/**/*'
+              - 'src/app/posts/_articles/**/*'
 
-eslint:
+feature:
   - any:
       - changed-files:
           - any-glob-to-any-file:
-              - 'eslint.*'
+              - 'src/app/**/*'
+              - 'src/components/**/*'
 
-tsconfig:
+style:
   - any:
       - changed-files:
           - any-glob-to-any-file:
+              - 'src/styles/**/*'
+              - '*.css'
+
+test:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file:
+              - 'tests/**/*'
+              - 'playwright.config.ts'
+
+config:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file:
+              - 'next.config.ts'
               - 'tsconfig.json'
-
-v2:
-  - any:
-      - head-branch: [ '^wip/v2$' ]
+              - 'biome.json'
+              - 'postcss.config.js'
 
 workflows:
   - any:
       - changed-files:
           - any-glob-to-any-file:
-              - '.github/workflows/**/*'
+              - '.github/**/*'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,8 +18,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,3 +44,7 @@ jobs:
 
       - name: Run E2E tests
         run: pnpm test:e2e
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_D1_DATABASE_ID: ${{ secrets.CLOUDFLARE_D1_DATABASE_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,8 +27,20 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps chromium webkit
+
+      - name: Install Playwright system deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium webkit
 
       - name: Run E2E tests
         run: pnpm test:e2e

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,36 @@
+name: E2E Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium webkit
+
+      - name: Run E2E tests
+        run: pnpm test:e2e

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,11 +36,11 @@ jobs:
 
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install --with-deps chromium webkit
+        run: pnpm exec playwright install --with-deps chromium
 
       - name: Install Playwright system deps
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: pnpm exec playwright install-deps chromium webkit
+        run: pnpm exec playwright install-deps chromium
 
       - name: Run E2E tests
         run: pnpm test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -403,4 +403,9 @@ public/content/**
 .claude
 .cursor
 
+# Playwright
+playwright-report/
+test-results/
+.playwright-mcp/
+
 # End of https://www.toptal.com/developers/gitignore/api/visualstudiocode,macos,windows,webstorm,git,node,nextjs,react

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "lint": "biome check --write",
     "type-check": "tsc --noEmit",
     "tw-sort": "biome lint --write --unsafe",
-    "check": "pnpm lint && pnpm type-check"
+    "check": "pnpm lint && pnpm type-check",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,jsonc}": "biome check --write "

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'mobile',
+      use: { ...devices['iPhone 13'] },
+    },
+  ],
+  webServer: {
+    command: 'pnpm dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
     },
     {
       name: 'mobile',
-      use: { ...devices['iPhone 13'] },
+      use: { ...devices['Pixel 5'] },
     },
   ],
   webServer: {

--- a/tests/e2e/about.spec.ts
+++ b/tests/e2e/about.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/test';
+import { ROUTES } from '../helpers/routes';
+
+test.describe('About Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(ROUTES.ABOUT);
+  });
+
+  test('페이지가 성공적으로 로드된다 (HTTP 200)', async ({ page }) => {
+    const response = await page.goto(ROUTES.ABOUT);
+    expect(response?.status()).toBe(200);
+  });
+
+  test('"Work Experience" 섹션이 렌더링된다', async ({ page }) => {
+    await expect(page.getByText('Work Experience')).toBeVisible();
+  });
+
+  test('"Achievements & Activities" 섹션이 렌더링된다', async ({ page }) => {
+    await expect(page.getByText(/achievements/i)).toBeVisible();
+  });
+});

--- a/tests/e2e/categories.spec.ts
+++ b/tests/e2e/categories.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from '@playwright/test';
+import { CATEGORY_SLUGS, ROUTES } from '../helpers/routes';
+
+test.describe('Categories List Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(ROUTES.CATEGORIES);
+  });
+
+  test('"Categories" 헤딩이 렌더링된다', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Categories' })).toBeVisible();
+  });
+
+  test('카테고리 목록 nav가 렌더링된다', async ({ page }) => {
+    const nav = page.getByRole('navigation', { name: /category list/i });
+    await expect(nav).toBeVisible();
+    await expect(nav.getByRole('listitem').first()).toBeVisible();
+  });
+
+  test('카테고리 항목 클릭 시 해당 카테고리 페이지로 이동한다', async ({ page }) => {
+    const nav = page.getByRole('navigation', { name: /category list/i });
+    const firstLink = nav.getByRole('link').first();
+    const href = await firstLink.getAttribute('href');
+
+    await firstLink.click();
+    await expect(page).toHaveURL(href ?? '');
+    await expect(page.url()).toContain('/categories/');
+  });
+});
+
+test.describe('Category Detail Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(ROUTES.CATEGORY(CATEGORY_SLUGS.FILM));
+  });
+
+  test('카테고리 이름이 포함된 헤딩이 렌더링된다', async ({ page }) => {
+    const heading = page.getByRole('heading', { level: 1 });
+    await expect(heading).toBeVisible();
+    await expect(heading).toContainText('Film');
+  });
+
+  test('해당 카테고리의 포스트 목록이 렌더링된다', async ({ page }) => {
+    const list = page.getByRole('list');
+    await expect(list.getByRole('listitem').first()).toBeVisible();
+  });
+});

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test';
+import { ROUTES } from '../helpers/routes';
+
+test.describe('Home Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(ROUTES.HOME);
+  });
+
+  test('"Update" 섹션이 렌더링된다', async ({ page }) => {
+    const section = page.getByRole('region', { name: /update/i });
+    await expect(section).toBeVisible();
+  });
+
+  test('"Expand" 링크가 /posts로 연결된다', async ({ page }) => {
+    const expandLink = page.getByRole('link', { name: /expand/i });
+    await expect(expandLink).toHaveAttribute('href', ROUTES.POSTS);
+  });
+
+  test('포스트 카드가 최소 1개 이상 렌더링된다', async ({ page }) => {
+    const section = page.getByRole('region', { name: /update/i });
+    const cards = section.getByRole('link', { name: /read post/i });
+    await expect(cards.first()).toBeVisible();
+  });
+
+  test('포스트 카드 클릭 시 해당 포스트 상세 페이지로 이동한다', async ({ page }) => {
+    const section = page.getByRole('region', { name: /update/i });
+    const firstCard = section.getByRole('link', { name: /read post/i }).first();
+    const href = await firstCard.getAttribute('href');
+
+    await firstCard.click();
+    await expect(page).toHaveURL(href ?? '');
+    await expect(page.url()).toContain('/posts/');
+  });
+});

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from '@playwright/test';
+import { openMobileMenu } from '../helpers/mobile';
+import { ROUTES } from '../helpers/routes';
+
+test.describe('Navigation', () => {
+  test('사이드바/헤더에 메뉴 항목이 렌더링된다', async ({ page, isMobile }) => {
+    await page.goto(ROUTES.HOME);
+    await openMobileMenu(page, isMobile);
+
+    const nav = page.getByRole('navigation', { name: /navigation/i });
+    await expect(nav.getByRole('link', { name: 'Home' })).toBeVisible();
+    await expect(nav.getByRole('link', { name: 'About' })).toBeVisible();
+    await expect(nav.getByRole('link', { name: 'Posts' })).toBeVisible();
+  });
+
+  test('About 링크를 클릭하면 /about으로 이동한다', async ({ page, isMobile }) => {
+    await page.goto(ROUTES.HOME);
+    await openMobileMenu(page, isMobile);
+
+    const nav = page.getByRole('navigation', { name: /navigation/i });
+    await nav.getByRole('link', { name: 'About' }).click();
+
+    await expect(page).toHaveURL(ROUTES.ABOUT);
+  });
+
+  test('Posts 링크를 클릭하면 /posts로 이동한다', async ({ page, isMobile }) => {
+    await page.goto(ROUTES.HOME);
+    await openMobileMenu(page, isMobile);
+
+    const nav = page.getByRole('navigation', { name: /navigation/i });
+    await nav.getByRole('link', { name: 'Posts' }).click();
+
+    await expect(page).toHaveURL(ROUTES.POSTS);
+  });
+
+  test('현재 페이지의 메뉴 항목에 aria-current="page"가 설정된다', async ({ page, isMobile }) => {
+    await page.goto(ROUTES.POSTS);
+    await openMobileMenu(page, isMobile);
+
+    const nav = page.getByRole('navigation', { name: /navigation/i });
+    const postsLink = nav.getByRole('link', { name: 'Posts' });
+    await expect(postsLink).toHaveAttribute('aria-current', 'page');
+  });
+
+  test('로고를 클릭하면 홈으로 이동한다', async ({ page }) => {
+    await page.goto(ROUTES.ABOUT);
+
+    await page.getByRole('link', { name: 'Hyunsoo Ro' }).first().click();
+    await expect(page).toHaveURL(ROUTES.HOME);
+  });
+});

--- a/tests/e2e/not-found.spec.ts
+++ b/tests/e2e/not-found.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@playwright/test';
+import { ROUTES } from '../helpers/routes';
+
+test.describe('404 Not Found Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/this-route-definitely-does-not-exist');
+  });
+
+  test('"404" 텍스트가 표시된다', async ({ page }) => {
+    await expect(page.getByText('404')).toBeVisible();
+  });
+
+  test('"Not Found Page" 헤딩이 표시된다', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: /not found/i })).toBeVisible();
+  });
+
+  test('"Home" 버튼이 홈으로 연결된다', async ({ page }) => {
+    // nav의 Home 링크와 구분하기 위해 ui-button 클래스를 가진 Home 링크를 선택
+    const homeLink = page.locator('a.ui-button', { hasText: 'Home' });
+    await expect(homeLink).toBeVisible();
+    await homeLink.click();
+    await expect(page).toHaveURL(ROUTES.HOME);
+  });
+});

--- a/tests/e2e/post-detail.spec.ts
+++ b/tests/e2e/post-detail.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from '@playwright/test';
+import { ROUTES, SLUGS } from '../helpers/routes';
+
+test.describe('Post Detail Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(ROUTES.POST(SLUGS.FILM_01));
+  });
+
+  test('article 요소가 렌더링된다', async ({ page }) => {
+    await expect(page.getByRole('article')).toBeVisible();
+  });
+
+  test('뒤로가기 버튼이 존재한다', async ({ page }) => {
+    const backBtn = page.getByRole('button', { name: /go back/i }).first();
+    await expect(backBtn).toBeVisible();
+  });
+
+  test('뒤로가기 버튼 클릭 시 포스트 목록으로 이동한다', async ({ page }) => {
+    await page
+      .getByRole('button', { name: /go back/i })
+      .first()
+      .click();
+    await expect(page).toHaveURL(ROUTES.POSTS);
+  });
+
+  test('포스트 제목이 렌더링된다', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+  });
+
+  test('추천 포스트 섹션이 렌더링된다', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: /check them out/i })).toBeVisible();
+  });
+
+  test('존재하지 않는 슬러그에서 404가 반환된다', async ({ page }) => {
+    await page.goto(ROUTES.POST('this-post-does-not-exist'));
+    await expect(page.getByRole('heading', { name: /not found/i })).toBeVisible();
+  });
+});

--- a/tests/e2e/posts.spec.ts
+++ b/tests/e2e/posts.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test } from '@playwright/test';
+import { ROUTES } from '../helpers/routes';
+
+test.describe('Posts List Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(ROUTES.POSTS);
+  });
+
+  test('"Posts (N)" 헤딩이 렌더링된다', async ({ page }) => {
+    const heading = page.getByRole('heading', { level: 1 });
+    await expect(heading).toBeVisible();
+    await expect(heading).toContainText('Posts');
+  });
+
+  test('포스트 목록에 항목이 1개 이상 있다', async ({ page }) => {
+    const list = page.getByRole('list');
+    const items = list.getByRole('listitem');
+    await expect(items.first()).toBeVisible();
+  });
+
+  test('포스트 항목 클릭 시 상세 페이지로 이동한다', async ({ page }) => {
+    const list = page.getByRole('list');
+    const firstItem = list.getByRole('listitem').first();
+    const link = firstItem.getByRole('link').first();
+    const href = await link.getAttribute('href');
+
+    await link.click();
+    await expect(page).toHaveURL(href ?? '');
+  });
+
+  test('포스트가 10개를 초과하면 페이지네이션이 표시된다', async ({ page }) => {
+    const heading = page.getByRole('heading', { level: 1 });
+    const headingText = await heading.textContent();
+    const match = headingText?.match(/\d+/);
+    const totalPosts = match ? parseInt(match[0], 10) : 0;
+
+    if (totalPosts > 10) {
+      const pagination = page.getByRole('navigation', { name: /pagination/i });
+      await expect(pagination).toBeVisible();
+      await expect(pagination.getByRole('link', { name: /next page/i })).toBeVisible();
+    } else {
+      test.info().annotations.push({
+        type: 'info',
+        description: `포스트 수 ${totalPosts}개 — 페이지네이션 없음, 스킵`,
+      });
+    }
+  });
+});
+
+test.describe('Posts Pagination', () => {
+  test('페이지 2 URL(/posts/p/2)이 유효하게 렌더링된다 (포스트 11개 이상인 경우)', async ({
+    page,
+  }) => {
+    await page.goto(ROUTES.POSTS);
+    const heading = page.getByRole('heading', { level: 1 });
+    const headingText = await heading.textContent();
+    const match = headingText?.match(/\d+/);
+    const totalPosts = match ? parseInt(match[0], 10) : 0;
+
+    if (totalPosts <= 10) {
+      test.skip(true, `포스트 수 ${totalPosts}개 — 페이지네이션 테스트 불필요`);
+    }
+
+    await page.goto(ROUTES.POSTS_PAGE(2));
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Posts');
+    const pagination = page.getByRole('navigation', { name: /pagination/i });
+    const currentPageSpan = pagination.locator('[aria-current="page"]');
+    await expect(currentPageSpan).toHaveText('2');
+  });
+});

--- a/tests/e2e/tags.spec.ts
+++ b/tests/e2e/tags.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from '@playwright/test';
+import { ROUTES, TAG_SLUGS } from '../helpers/routes';
+
+test.describe('Tags List Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(ROUTES.TAGS);
+  });
+
+  test('"Tags" 헤딩이 렌더링된다', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Tags' })).toBeVisible();
+  });
+
+  test('태그 목록 nav가 렌더링된다', async ({ page }) => {
+    const nav = page.getByRole('navigation', { name: /tag list/i });
+    await expect(nav).toBeVisible();
+    await expect(nav.getByRole('listitem').first()).toBeVisible();
+  });
+
+  test('태그 항목 클릭 시 해당 태그 페이지로 이동한다', async ({ page }) => {
+    const nav = page.getByRole('navigation', { name: /tag list/i });
+    const firstLink = nav.getByRole('link').first();
+    const href = await firstLink.getAttribute('href');
+
+    await firstLink.click();
+    await expect(page).toHaveURL(href ?? '');
+    await expect(page.url()).toContain('/tags/');
+  });
+});
+
+test.describe('Tag Detail Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(ROUTES.TAG(TAG_SLUGS.PHOTO));
+  });
+
+  test('태그 이름이 포함된 헤딩이 렌더링된다', async ({ page }) => {
+    const heading = page.getByRole('heading', { level: 1 });
+    await expect(heading).toBeVisible();
+    await expect(heading).toContainText('photo');
+  });
+
+  test('해당 태그의 포스트 목록이 렌더링된다', async ({ page }) => {
+    const list = page.getByRole('list');
+    await expect(list.getByRole('listitem').first()).toBeVisible();
+  });
+});

--- a/tests/e2e/theme.spec.ts
+++ b/tests/e2e/theme.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@playwright/test';
+import { openMobileMenu } from '../helpers/mobile';
+import { ROUTES } from '../helpers/routes';
+
+test.describe('Theme Toggle', () => {
+  test('ThemeToggle 버튼이 렌더링된다', async ({ page, isMobile }) => {
+    await page.goto(ROUTES.HOME);
+    await openMobileMenu(page, isMobile);
+    const toggleBtn = page.getByRole('button', { name: /toggle dark or light mode/i }).first();
+    await expect(toggleBtn).toBeVisible();
+  });
+
+  test('토글 클릭 시 테마가 전환된다', async ({ page, isMobile }) => {
+    await page.goto(ROUTES.HOME);
+    await openMobileMenu(page, isMobile);
+    const toggleBtn = page.getByRole('button', { name: /toggle dark or light mode/i }).first();
+
+    const htmlEl = page.locator('html');
+    const before = await htmlEl.getAttribute('class');
+
+    await toggleBtn.click();
+
+    const after = await htmlEl.getAttribute('class');
+    expect(before).not.toEqual(after);
+  });
+
+  test('테마 전환 후 페이지 이동해도 테마가 유지된다', async ({ page, isMobile }) => {
+    await page.goto(ROUTES.HOME);
+    await openMobileMenu(page, isMobile);
+    const toggleBtn = page.getByRole('button', { name: /toggle dark or light mode/i }).first();
+
+    await toggleBtn.click();
+    const themeAfterToggle = await page.locator('html').getAttribute('class');
+
+    await page.goto(ROUTES.POSTS);
+    const themeAfterNav = await page.locator('html').getAttribute('class');
+
+    expect(themeAfterToggle).toEqual(themeAfterNav);
+  });
+});

--- a/tests/helpers/mobile.ts
+++ b/tests/helpers/mobile.ts
@@ -1,0 +1,8 @@
+import type { Page } from '@playwright/test';
+
+export const openMobileMenu = async (page: Page, isMobile: boolean | undefined) => {
+  if (!isMobile) return;
+  const menuBtn = page.locator('button[aria-controls="menu-accordion-content"]');
+  await menuBtn.waitFor({ state: 'visible' });
+  await menuBtn.click();
+};

--- a/tests/helpers/routes.ts
+++ b/tests/helpers/routes.ts
@@ -1,0 +1,25 @@
+export const ROUTES = {
+  HOME: '/',
+  ABOUT: '/about',
+  POSTS: '/posts',
+  POSTS_PAGE: (page: number) => (page === 1 ? '/posts' : `/posts/p/${page}`),
+  POST: (slug: string) => `/posts/${slug}`,
+  CATEGORIES: '/categories',
+  CATEGORY: (slug: string) => `/categories/${slug}`,
+  TAGS: '/tags',
+  TAG: (slug: string) => `/tags/${slug}`,
+} as const;
+
+export const SLUGS = {
+  FILM_01: 'filmlog-01',
+  FILM_02: 'filmlog-02',
+  ISTQB: 'istqb-ctfl-pass-review',
+} as const;
+
+export const CATEGORY_SLUGS = {
+  FILM: 'film',
+} as const;
+
+export const TAG_SLUGS = {
+  PHOTO: 'photo',
+} as const;


### PR DESCRIPTION
## Summary
- Switched mobile project target in CI from iPhone 13 to Pixel 5 to reduce CI time
- Injected Cloudflare environment variables from GitHub Secrets in CI
- Updated labeler configuration to match the current project structure
- Fixed pnpm version conflict in CI workflow
- Added GitHub Actions workflow for E2E tests on pull requests
- Added Playwright E2E test suite covering core user journeys

## Changes
- `.github/workflows/ci.yml`: Updated mobile project target and fixed pnpm version conflict
- `.github/workflows/e2e.yml`: Added new workflow for E2E tests
- `.github/labeler.yml`: Updated labeler configuration
- `tests/e2e/`: Added Playwright test suite for core user journeys

## Test Plan
- [x] Verify CI runs successfully with updated mobile target and pnpm version fix
- [x] Confirm Cloudflare environment variables are correctly injected from GitHub Secrets
- [x] Ensure labeler applies correct labels based on the updated configuration
- [x] Validate E2E tests run successfully in the new workflow
- [x] Review Playwright test suite for completeness and accuracy

## Notes
> Duplicate commit for injecting Cloudflare environment variables was squashed into a single change.