### PR TITLE
update ci to use node 24 and increase workers

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   e2e:
     runs-on: ubuntu-latest

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 2 : undefined,
   reporter: 'html',
   use: {
     baseURL: 'http://localhost:3000',


### PR DESCRIPTION
## Summary
- Updated CI configuration to enforce Node.js version 24
- Increased the number of CI workers to 2

## Changes
- Modified CI workflow to specify Node.js 24
- Adjusted CI settings to use 2 workers

## Test Plan
- [x] Verify CI runs successfully with Node.js 24
- [x] Confirm that CI utilizes 2 workers as expected