### PR TITLE
update giscus language to english

### DIFF
--- a/src/app/posts/[slug]/_components/giscus.tsx
+++ b/src/app/posts/[slug]/_components/giscus.tsx
@@ -45,7 +45,7 @@ export const Giscus = ({ ...props }: GiscusProps) => {
       script.setAttribute('data-emit-metadata', '0');
       script.setAttribute('data-input-position', 'bottom');
       script.setAttribute('data-theme', theme);
-      script.setAttribute('data-lang', 'ko');
+      script.setAttribute('data-lang', 'en');
       script.setAttribute('crossorigin', 'anonymous');
       script.addEventListener('load', postThemeUpdate, { once: true });
       container.appendChild(script);


### PR DESCRIPTION
## Summary
- Changed the giscus comment system language from Korean (ko) to English (en)

## Changes
- Updated giscus language configuration

## Test Plan
- [x] Verify that the giscus comment system displays in English

## Notes
> This change ensures that the comment system is accessible to a broader audience by default.