### PR TITLE
fix shimmer aspect ratio with build-time image size resolution

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -40,6 +40,7 @@ const nextConfig: NextConfig = {
     },
   },
   images: {
+    minimumCacheTTL: 2592000,
     qualities: [75, 100],
     remotePatterns: [
       {

--- a/src/components/ui/lazyImage.tsx
+++ b/src/components/ui/lazyImage.tsx
@@ -8,6 +8,8 @@ import { twMerge } from 'tailwind-merge';
 export type LazyImageProps = {
   src: string;
   alt: string;
+  width?: number;
+  height?: number;
   className?: string;
   draggable?: boolean;
   title?: string;
@@ -18,6 +20,8 @@ export type LazyImageProps = {
 export const LazyImage = ({
   src,
   alt,
+  width = 1200,
+  height = 800,
   className,
   draggable = false,
   title,
@@ -27,7 +31,10 @@ export const LazyImage = ({
   const [isLoaded, setIsLoaded] = useState(false);
 
   return (
-    <span className='relative block overflow-hidden'>
+    <span
+      className='relative block overflow-hidden'
+      style={{ aspectRatio: `${width} / ${height}` }}
+    >
       {!isLoaded && (
         <span className='absolute inset-0 animate-shimmer bg-[linear-gradient(90deg,var(--color-background02)_25%,var(--color-border)_50%,var(--color-background02)_75%)] bg-[length:200%_100%]' />
       )}
@@ -39,7 +46,7 @@ export const LazyImage = ({
           className
         )}
         draggable={draggable}
-        height={800}
+        height={height}
         onLoad={() => {
           setIsLoaded(true);
           onLoad?.();
@@ -48,7 +55,7 @@ export const LazyImage = ({
         src={src}
         style={style}
         title={title}
-        width={1200}
+        width={width}
       />
     </span>
   );

--- a/src/components/ui/mdxComponent.tsx
+++ b/src/components/ui/mdxComponent.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import type { ComponentProps, ReactNode } from 'react';
+import { cache } from 'react';
 import { codeToHtml, createCssVariablesTheme } from 'shiki';
 import { twMerge } from 'tailwind-merge';
 
@@ -157,6 +158,22 @@ const Code = async (props: CodeProps) => {
   return <code className='inline' {...props} />;
 };
 
+const getImageSize = cache(
+  async (url: string): Promise<{ width: number; height: number } | null> => {
+    try {
+      const response = await fetch(url);
+      if (!response.ok) return null;
+      const buffer = Buffer.from(await response.arrayBuffer());
+      const sharp = (await import('sharp')).default;
+      const { width, height } = await sharp(buffer).metadata();
+      if (!width || !height) return null;
+      return { width, height };
+    } catch {
+      return null;
+    }
+  }
+);
+
 type ImgProps = Omit<ComponentProps<'img'>, 'src' | 'alt'> & {
   src?: string;
   alt?: string;
@@ -167,14 +184,17 @@ const Img = async ({ src, alt, ...props }: ImgProps) => {
   }
 
   if (src.startsWith('https://')) {
+    const size = await getImageSize(src);
     return (
       <LazyImage
         alt={alt ?? ''}
         className={twMerge('h-auto max-w-full', props.className)}
         draggable={props.draggable === true || props.draggable === 'true'}
+        height={size?.height}
         src={src}
         style={props.style}
         title={props.title}
+        width={size?.width}
       />
     );
   }


### PR DESCRIPTION
## Summary
- Improved the shimmer effect by resolving image aspect ratios at build time.

## Changes
- Updated logic to calculate and apply correct aspect ratios for shimmer placeholders.

## Test Plan
- [ ] Verify that shimmer placeholders maintain correct aspect ratios across different image sizes.
- [ ] Test the functionality on various screen resolutions and devices.
- [ ] Ensure no regressions in existing shimmer behavior.

## Notes
> This change optimizes the shimmer effect by leveraging build-time image size data, which improves performance and visual consistency.