### PR TITLE
fix: replace Link with anchor tag for RSS and sitemap routes

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -82,7 +82,7 @@ export const Header = () => {
                     {METADATA.AUTHOR.NAME}, All rights reserved.
                   </p>
                   <div className='row-between mx-auto max-w-30.5 mt-4 gap-2'>
-                    <Link
+                    <a
                       aria-label='RSS feed'
                       className='flex h7 items-center gap-1 text-license no-underline opacity-100 transition-opacity duration-150 ease-in-out hover:opacity-70'
                       href={ROUTES.RSS}
@@ -91,8 +91,8 @@ export const Header = () => {
                     >
                       <Rss size={14} />
                       RSS
-                    </Link>
-                    <Link
+                    </a>
+                    <a
                       aria-label='XML sitemap'
                       className='flex h7 items-center gap-1 text-license no-underline opacity-100 transition-opacity duration-150 ease-in-out hover:opacity-70'
                       href={ROUTES.SITEMAP}
@@ -101,7 +101,7 @@ export const Header = () => {
                     >
                       <Network size={14} />
                       Sitemap
-                    </Link>
+                    </a>
                   </div>
                 </div>
               </Accordion.Content>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -36,7 +36,7 @@ export const Sidebar = () => {
             {METADATA.AUTHOR.NAME}, All rights reserved.
           </p>
           <div className='row-between'>
-            <Link
+            <a
               aria-label='RSS feed'
               className='flex h6 items-center gap-1 text-license no-underline opacity-100 transition-opacity duration-150 ease-in-out hover:opacity-70'
               href={ROUTES.RSS}
@@ -45,8 +45,8 @@ export const Sidebar = () => {
             >
               <Rss size={16} />
               RSS
-            </Link>
-            <Link
+            </a>
+            <a
               aria-label='XML sitemap'
               className='flex h6 items-center gap-1 text-license no-underline opacity-100 transition-opacity duration-150 ease-in-out hover:opacity-70'
               href={ROUTES.SITEMAP}
@@ -55,7 +55,7 @@ export const Sidebar = () => {
             >
               <Network size={16} />
               Sitemap
-            </Link>
+            </a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Replaced `Link` components with anchor tags for RSS and sitemap routes.
- Fixed 404 errors caused by `Link` triggering RSC prefetch on route handlers.

## Changes
- Updated RSS and sitemap route links to use `<a>` tags instead of `<Link>`.

## Test Plan
- [x] Verify that RSS and sitemap routes load correctly without 404 errors.
- [x] Confirm that the changes do not affect other routes or functionality.

## Notes
> RSS and sitemap.xml are route handlers, not Next.js pages, which caused issues with `Link` prefetching.