### PR TITLE
fix: improve view count loading and hydration behavior

### DIFF
--- a/src/app/posts/[slug]/_components/view-counter.tsx
+++ b/src/app/posts/[slug]/_components/view-counter.tsx
@@ -5,12 +5,11 @@ import { useStatsMutation, useStatsQuery } from '@/hooks/useStats';
 
 interface ViewCounterProps {
   pathname: string;
-  initialTotal: number;
 }
 
-export const ViewCounter = ({ pathname, initialTotal }: ViewCounterProps) => {
+export const ViewCounter = ({ pathname }: ViewCounterProps) => {
   const hasCounted = useRef(false);
-  const { data } = useStatsQuery(pathname, { today: 0, total: initialTotal });
+  const { data } = useStatsQuery(pathname);
   const { mutate } = useStatsMutation(pathname);
 
   useEffect(() => {
@@ -19,5 +18,5 @@ export const ViewCounter = ({ pathname, initialTotal }: ViewCounterProps) => {
     mutate();
   }, [mutate]);
 
-  return <span>{data.total.toLocaleString()} views</span>;
+  return <span>{data ? data.total.toLocaleString() : '-'} views</span>;
 };

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -68,7 +68,7 @@ const PostPage = async ({ params }: PostPageProps) => {
       <BackButton />
 
       <article>
-        <Header {...post} viewCounter={<ViewCounter initialTotal={0} pathname={pathname} />} />
+        <Header {...post} viewCounter={<ViewCounter pathname={pathname} />} />
         <MDXContent />
 
         {post.comments && <Giscus className='mt-14' />}

--- a/src/components/StatsWidget/StatsWidgetClient.tsx
+++ b/src/components/StatsWidget/StatsWidgetClient.tsx
@@ -40,8 +40,8 @@ export const StatsWidgetClient = ({ postCount, initialStats }: StatsWidgetClient
     mutate();
   }, [mutate]);
 
-  const todayCount = useCountUp(stats.today);
-  const totalCount = useCountUp(stats.total);
+  const todayCount = useCountUp(stats?.today ?? 0);
+  const totalCount = useCountUp(stats?.total ?? 0);
   const postCountAnimated = useCountUp(postCount, 800);
 
   return (

--- a/src/components/ui/postGrid.tsx
+++ b/src/components/ui/postGrid.tsx
@@ -54,10 +54,8 @@ export const PostGrid = ({ posts, className, ...props }: PostGridProps) => {
 
             <p className='description h4 center-y -mx-2.5 mt-4 -mb-0.5 w-fit rounded-sm px-2.5 py-0.5 text-gray-light transition-colors duration-250 ease-in-out'>
               <RelativeTime time={createdAt} />
-              <span className='ml-4 tabular-nums'>
-                {viewsState.status === 'loading'
-                  ? '-'
-                  : `${(viewCount ?? 0).toLocaleString()} views`}
+              <span className='ml-4 tabular-nums' suppressHydrationWarning>
+                {viewsState.status === 'loading' ? '-' : (viewCount ?? 0).toLocaleString()} views
               </span>
             </p>
           </Link>

--- a/src/components/ui/postList.tsx
+++ b/src/components/ui/postList.tsx
@@ -69,10 +69,9 @@ export const PostList = ({ posts, className, ...props }: PostListProps) => {
                         {category}
                       </>
                     )}
-                    <span className='ml-4 tabular-nums'>
-                      {viewsState.status === 'loading'
-                        ? '-'
-                        : `${(viewCount ?? 0).toLocaleString()} views`}
+                    <span className='ml-4 tabular-nums' suppressHydrationWarning>
+                      {viewsState.status === 'loading' ? '-' : (viewCount ?? 0).toLocaleString()}{' '}
+                      views
                     </span>
                   </p>
                 </div>

--- a/src/hooks/usePostViews.ts
+++ b/src/hooks/usePostViews.ts
@@ -1,26 +1,29 @@
 'use client';
 
+import { usePathname } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
 
 type ViewsState = { status: 'loading' } | { status: 'done'; data: Record<string, number> };
 
 export const usePostViews = (slugs: string[]): ViewsState => {
   const key = useMemo(() => slugs.join(','), [slugs]);
+  const pathname = usePathname();
   const [state, setState] = useState<ViewsState>({ status: 'loading' });
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: pathname triggers refetch on navigation back to listing pages
   useEffect(() => {
     if (!key) {
       setState({ status: 'done', data: {} });
       return;
     }
     setState({ status: 'loading' });
-    fetch(`/api/views?slugs=${key}`)
+    fetch(`/api/views?slugs=${key}`, { cache: 'no-store' })
       .then((r) => r.json())
       .then((data) => setState({ status: 'done', data }))
       .catch((_e: unknown) => {
         setState({ status: 'done', data: {} });
       });
-  }, [key]);
+  }, [key, pathname]);
 
   return state;
 };

--- a/src/hooks/useStats.ts
+++ b/src/hooks/useStats.ts
@@ -17,11 +17,11 @@ const postStats = async (pathname: string): Promise<{ ok: boolean; counted: bool
   return res.json() as Promise<{ ok: boolean; counted: boolean }>;
 };
 
-export function useStatsQuery(pathname: string, initialData: Stats) {
+export function useStatsQuery(pathname: string, initialData?: Stats) {
   return useQuery({
     queryKey: statsQueryKey(pathname),
     queryFn: () => fetchStats(pathname),
-    initialData,
+    ...(initialData && { initialData }),
     staleTime: 60_000,
   });
 }


### PR DESCRIPTION
## Summary
- Show "- views" placeholder while view counts are loading
- Fix hydration mismatch with `suppressHydrationWarning` on views span
- Refetch view counts on pathname change to sync after visiting a post
- Make `initialData` optional in `useStatsQuery` to avoid breaking `StatsWidget`

## Changes
- Updated view count placeholder to display "- views" during fetch
- Added `suppressHydrationWarning` to views span to fix hydration mismatch
- Modified logic to refetch view counts on pathname change
- Adjusted `useStatsQuery` to make `initialData` optional

## Test Plan
- [ ] Verify placeholder displays "- views" while loading view counts
- [ ] Confirm no hydration mismatch warnings in console
- [ ] Ensure view counts update correctly after navigating to a post
- [ ] Test `StatsWidget` functionality without `initialData`