### PR TITLE
fix: normalize empty pathname for home menu

### DIFF
--- a/src/components/layout/NavigateMenu.tsx
+++ b/src/components/layout/NavigateMenu.tsx
@@ -7,6 +7,7 @@ import { MENU } from '@/constants/menu.constants';
 
 export const NavigateMenu = () => {
   const pathname = usePathname();
+  const normalizedPathname = pathname || '/';
 
   return (
     <nav aria-label='Main navigation'>
@@ -14,8 +15,8 @@ export const NavigateMenu = () => {
         {MENU.map((menu) => {
           const isActive =
             menu.link === '/'
-              ? pathname === '/'
-              : pathname === menu.link || pathname.startsWith(`${menu.link}/`);
+              ? normalizedPathname === '/'
+              : normalizedPathname === menu.link || normalizedPathname.startsWith(`${menu.link}/`);
           return (
             <li
               className={twMerge(


### PR DESCRIPTION
## Summary
- Treat empty pathname as root in navigation active state
- Fix missing Home active style on production refresh

## Changes
- Updated logic to handle empty pathname as root in navigation
- Fixed styling issue for Home menu active state on page refresh

## Test Plan
- [x] Verify Home menu is correctly marked as active when the pathname is empty
- [x] Confirm Home menu active style persists after refreshing the page in production

## Notes
> Treating empty pathname as root ensures consistent navigation behavior.