### PR TITLE
include projects in feeds

### DIFF
--- a/src/app/rss.xml/route.ts
+++ b/src/app/rss.xml/route.ts
@@ -2,6 +2,7 @@ import dayjs from 'dayjs';
 import { ROUTES } from '@/constants/menu.constants';
 import { METADATA } from '@/constants/metadata.constants';
 import { getAllPosts } from '@/utils/post-util';
+import { getAllProjects } from '@/utils/project-util';
 import { slugify } from '@/utils/text-util';
 import { escapeXml, toCdata } from '@/utils/xml-util';
 
@@ -16,9 +17,9 @@ const generateRssItems = async (): Promise<
     pubDate: string;
   }[]
 > => {
-  const allPosts = await getAllPosts();
+  const [allPosts, allProjects] = await Promise.all([getAllPosts(), getAllProjects()]);
 
-  return allPosts.map(({ title, slug, subtitle, modifiedAt, createdAt }) => {
+  const postItems = allPosts.map(({ title, slug, subtitle, modifiedAt, createdAt }) => {
     const date = modifiedAt ?? createdAt;
     const pubDate = dayjs(date).toDate().toUTCString();
     const description = subtitle;
@@ -30,6 +31,22 @@ const generateRssItems = async (): Promise<
       pubDate,
     };
   });
+
+  const projectItems = allProjects.map(({ title, slug, description, projectDue, createdAt }) => {
+    const date = projectDue ?? createdAt;
+    const pubDate = dayjs(date).toDate().toUTCString();
+
+    return {
+      title,
+      link: `${METADATA.SITE.URL}${ROUTES.PROJECTS}/${slugify(slug)}`,
+      description,
+      pubDate,
+    };
+  });
+
+  return [...postItems, ...projectItems].sort(
+    (a, b) => dayjs(b.pubDate).valueOf() - dayjs(a.pubDate).valueOf()
+  );
 };
 
 interface RssItem {

--- a/src/app/sitemap.xml/route.ts
+++ b/src/app/sitemap.xml/route.ts
@@ -2,6 +2,7 @@ import type { MetadataRoute } from 'next';
 import { ROUTES } from '@/constants/menu.constants';
 import { METADATA, POST } from '@/constants/metadata.constants';
 import { getAllPosts } from '@/utils/post-util';
+import { getAllProjects } from '@/utils/project-util';
 import { slugify } from '@/utils/text-util';
 import { escapeXml } from '@/utils/xml-util';
 
@@ -9,7 +10,7 @@ export const dynamic = 'force-static';
 export const revalidate = false;
 
 const generateSitemapUrls = async (): Promise<MetadataRoute.Sitemap> => {
-  const posts = await getAllPosts();
+  const [posts, projects] = await Promise.all([getAllPosts(), getAllProjects()]);
   const postsPageCount = Math.ceil(posts.length / POST.PER_PAGE);
 
   const categoryCountMap = posts.reduce<Record<string, number>>((map, { category }) => {
@@ -56,6 +57,7 @@ const generateSitemapUrls = async (): Promise<MetadataRoute.Sitemap> => {
     { url: `${METADATA.SITE.URL}${ROUTES.CATEGORIES}` },
     { url: `${METADATA.SITE.URL}${ROUTES.TAGS}` },
     { url: `${METADATA.SITE.URL}${ROUTES.POSTS}` },
+    { url: `${METADATA.SITE.URL}${ROUTES.PROJECTS}` },
     ...categoryUrls,
     ...tagUrls,
     ...Array.from({ length: Math.max(0, postsPageCount - 1) }, (_, pageIndex) => ({
@@ -66,6 +68,12 @@ const generateSitemapUrls = async (): Promise<MetadataRoute.Sitemap> => {
       lastModified: modifiedAt ?? createdAt,
       changeFrequency: 'monthly',
       priority: 0.9,
+    })),
+    ...projects.map(({ slug, projectDue, createdAt }) => ({
+      url: `${METADATA.SITE.URL}${ROUTES.PROJECTS}/${slug}`,
+      lastModified: projectDue ?? createdAt,
+      changeFrequency: 'monthly',
+      priority: 0.8,
     })),
   ];
 };


### PR DESCRIPTION
## Summary
- Added functionality to include projects in feeds

## Changes
- Updated logic to fetch and display projects in feed-related components
- Modified relevant data models to support project inclusion

## Test Plan
- [ ] Verify that projects appear correctly in feeds
- [ ] Test feed functionality with and without projects
- [ ] Ensure no regressions in existing feed behavior

## Notes
> Ensure to test with various project types and edge cases.