### PR TITLE
refactor: merge footer and share button

### DIFF
--- a/src/app/posts/[slug]/_components/footer.tsx
+++ b/src/app/posts/[slug]/_components/footer.tsx
@@ -1,90 +1,21 @@
 'use client';
 
-import { toast } from 'sonner';
-import { ShareIcon } from '@/components/icons/ShareIcon';
+import { ContentFooter } from '@/components/ui/contentFooter';
 import { ROUTES } from '@/constants/menu.constants';
 import { METADATA } from '@/constants/metadata.constants';
 
 import type { Post } from '@/types/post.types';
 import { BackButton } from './back-button';
 
-export const Footer = ({ slug, title, subtitle }: Post) => {
-  const copyText = async (text: string): Promise<boolean> => {
-    try {
-      if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
-        await navigator.clipboard.writeText(text);
-        return true;
-      }
-
-      const textarea = document.createElement('textarea');
-      textarea.value = text;
-      textarea.setAttribute('readonly', '');
-      textarea.style.position = 'fixed';
-      textarea.style.left = '-9999px';
-      textarea.style.top = '-9999px';
-      document.body.appendChild(textarea);
-      textarea.select();
-
-      const ok = document.execCommand('copy');
-      document.body.removeChild(textarea);
-      return ok;
-    } catch {
-      return false;
-    }
-  };
-
-  const handleShare = async () => {
-    const shareData = {
-      title,
-      text: subtitle,
-      url: `${METADATA.SITE.URL}${ROUTES.POSTS}/${slug}`,
-    };
-
-    const canShare =
-      typeof navigator !== 'undefined' &&
-      typeof navigator.share === 'function' &&
-      (typeof navigator.canShare !== 'function' || navigator.canShare(shareData));
-
-    let shared = false;
-
-    if (canShare) {
-      try {
-        await navigator.share(shareData);
-        shared = true;
-      } catch (error) {
-        if (error instanceof DOMException && error.name === 'AbortError') {
-          return;
-        }
-
-        shared = false;
-      }
-    }
-
-    if (shared) {
-      return;
-    }
-
-    const copied = await copyText(shareData.url);
-    if (!copied) {
-      toast.error('링크를 복사하지 못했어요');
-      return;
-    }
-
-    toast.success('링크가 클립보드에 복사되었어요');
-  };
+export const Footer = ({ slug }: Post) => {
+  const url = `${METADATA.SITE.URL}${ROUTES.POSTS}/${slug}`;
 
   return (
-    <footer className='row-between mt-14 flex-wrap gap-2'>
-      <BackButton />
-      <button
-        aria-label='Share this post'
-        className='focus-ring center-y h3 w-fit cursor-pointer select-none gap-2 py-1.25 pr-2.25 text-gray-accent opacity-100 transition-opacity duration-150 ease-in-out hover:opacity-70'
-        onClick={handleShare}
-        type='button'
-      >
-        Share this post
-        <ShareIcon size={18} />
-      </button>
-    </footer>
+    <ContentFooter
+      backButton={<BackButton />}
+      shareButtonAriaLabel='Share this post'
+      shareButtonLabel='Share this post'
+      url={url}
+    />
   );
 };

--- a/src/app/projects/[slug]/_components/footer.tsx
+++ b/src/app/projects/[slug]/_components/footer.tsx
@@ -1,89 +1,20 @@
 'use client';
 
-import { toast } from 'sonner';
-import { ShareIcon } from '@/components/icons/ShareIcon';
+import { ContentFooter } from '@/components/ui/contentFooter';
 import { ROUTES } from '@/constants/menu.constants';
 import { METADATA } from '@/constants/metadata.constants';
 import type { Project } from '@/types/project.types';
 import { BackButton } from './back-button';
 
-export const Footer = ({ slug, title, description }: Project) => {
-  const copyText = async (text: string): Promise<boolean> => {
-    try {
-      if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
-        await navigator.clipboard.writeText(text);
-        return true;
-      }
-
-      const textarea = document.createElement('textarea');
-      textarea.value = text;
-      textarea.setAttribute('readonly', '');
-      textarea.style.position = 'fixed';
-      textarea.style.left = '-9999px';
-      textarea.style.top = '-9999px';
-      document.body.appendChild(textarea);
-      textarea.select();
-
-      const ok = document.execCommand('copy');
-      document.body.removeChild(textarea);
-      return ok;
-    } catch {
-      return false;
-    }
-  };
-
-  const handleShare = async () => {
-    const shareData = {
-      title,
-      text: description,
-      url: `${METADATA.SITE.URL}${ROUTES.PROJECTS}/${slug}`,
-    };
-
-    const canShare =
-      typeof navigator !== 'undefined' &&
-      typeof navigator.share === 'function' &&
-      (typeof navigator.canShare !== 'function' || navigator.canShare(shareData));
-
-    let shared = false;
-
-    if (canShare) {
-      try {
-        await navigator.share(shareData);
-        shared = true;
-      } catch (error) {
-        if (error instanceof DOMException && error.name === 'AbortError') {
-          return;
-        }
-
-        shared = false;
-      }
-    }
-
-    if (shared) {
-      return;
-    }
-
-    const copied = await copyText(shareData.url);
-    if (!copied) {
-      toast.error('링크를 복사하지 못했어요');
-      return;
-    }
-
-    toast.success('링크가 클립보드에 복사되었어요');
-  };
+export const Footer = ({ slug }: Project) => {
+  const url = `${METADATA.SITE.URL}${ROUTES.PROJECTS}/${slug}`;
 
   return (
-    <footer className='row-between mt-14 flex-wrap gap-2'>
-      <BackButton />
-      <button
-        aria-label='Share this project'
-        className='focus-ring center-y h3 w-fit cursor-pointer select-none gap-2 py-1.25 pr-2.25 text-gray-accent opacity-100 transition-opacity duration-150 ease-in-out hover:opacity-70'
-        onClick={handleShare}
-        type='button'
-      >
-        Share this project
-        <ShareIcon size={18} />
-      </button>
-    </footer>
+    <ContentFooter
+      backButton={<BackButton />}
+      shareButtonAriaLabel='Share this project'
+      shareButtonLabel='Share this project'
+      url={url}
+    />
   );
 };

--- a/src/components/ui/contentFooter.tsx
+++ b/src/components/ui/contentFooter.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { toast } from 'sonner';
+import { ShareIcon } from '@/components/icons/ShareIcon';
+
+type ContentFooterProps = {
+  backButton: ReactNode;
+  shareButtonLabel: string;
+  shareButtonAriaLabel: string;
+  url: string;
+};
+
+const copyText = async (text: string): Promise<boolean> => {
+  try {
+    if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.left = '-9999px';
+    textarea.style.top = '-9999px';
+    document.body.appendChild(textarea);
+    textarea.select();
+
+    const ok = document.execCommand('copy');
+    document.body.removeChild(textarea);
+    return ok;
+  } catch {
+    return false;
+  }
+};
+
+export const ContentFooter = ({
+  backButton,
+  shareButtonLabel,
+  shareButtonAriaLabel,
+  url,
+}: ContentFooterProps) => {
+  const handleShare = async () => {
+    const shareData = { url };
+
+    const canShare =
+      typeof navigator !== 'undefined' &&
+      typeof navigator.share === 'function' &&
+      (typeof navigator.canShare !== 'function' || navigator.canShare(shareData));
+
+    let shared = false;
+
+    if (canShare) {
+      try {
+        await navigator.share(shareData);
+        shared = true;
+      } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          return;
+        }
+
+        shared = false;
+      }
+    }
+
+    if (shared) {
+      return;
+    }
+
+    const copied = await copyText(url);
+    if (!copied) {
+      toast.error('링크를 복사하지 못했어요');
+      return;
+    }
+
+    toast.success('링크가 클립보드에 복사되었어요');
+  };
+
+  return (
+    <footer className='row-between mt-14 flex-wrap gap-2'>
+      {backButton}
+      <button
+        aria-label={shareButtonAriaLabel}
+        className='focus-ring center-y h3 w-fit cursor-pointer select-none gap-2 py-1.25 pr-2.25 text-gray-accent opacity-100 transition-opacity duration-150 ease-in-out hover:opacity-70'
+        onClick={handleShare}
+        type='button'
+      >
+        {shareButtonLabel}
+        <ShareIcon size={18} />
+      </button>
+    </footer>
+  );
+};


### PR DESCRIPTION
## Summary
- Combined detail footer and share button into a unified `ContentFooter` component
- Simplified post/project footer usage to support URL-only sharing

## Changes
- Refactored footer and share button into a single `ContentFooter` component
- Updated post and project components to use the new `ContentFooter` for URL sharing

## Test Plan
- [x] Verify `ContentFooter` displays correctly in post details
- [x] Verify `ContentFooter` displays correctly in project details
- [x] Test URL sharing functionality in both post and project footers